### PR TITLE
[DIGITALRIV-9] added post request for /tax-identifiers and returned customerId for createCheckout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a post request for /tax-identifiers
+- Returned customerId in createCheckout
+
 ## [1.1.2] - 2021-10-25
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -408,6 +408,64 @@ _Example Response:_
 }
 ```
 
+
+| Field            | Value                                                                                       |
+|------------------|---------------------------------------------------------------------------------------------|
+| **URI**          | /_v/api/digital-river/tax-identifiers                                                       |
+| **METHOD**       | POST                                                                                         |
+| **API Usage**    | Returns the created tax id. [Digital River API](https://www.digitalriver.com/docs/digital-river-api-reference/#operation/createTaxIdentifiers) |
+
+_Example Headers:_
+orderFormId: **orderFormId**
+
+> ⚠️ _There must be an email associated with the orderFormId_
+
+_Example Request:_
+```json
+{
+    "type": "uk",
+    "value": "GB999999999"
+}
+```
+
+_Example Response:_
+```json
+{
+    "id": "0ea76f4b-372a-41c1-9488-b0a8b13ade58",
+    "state": "verified",
+    "liveMode": false,
+    "type": "uk",
+    "value": "GB999999999",
+    "stateTransitions": {
+        "verified": "2021-10-28T20:41:20Z"
+    },
+    "createdTime": "2021-10-28T20:41:20Z",
+    "updatedTime": "2021-10-28T20:41:20Z",
+    "applicability": [
+        {
+            "country": "IM",
+            "entity": "DR_UK-ENTITY",
+            "customerType": "business"
+        },
+        {
+            "country": "IM",
+            "entity": "DR_IRELAND-ENTITY",
+            "customerType": "business"
+        },
+        {
+            "country": "GB",
+            "entity": "DR_UK-ENTITY",
+            "customerType": "business"
+        },
+        {
+            "country": "GB",
+            "entity": "DR_IRELAND-ENTITY",
+            "customerType": "business"
+        }
+    ]
+}
+```
+
 > ⚠️ _For `/tax-identifiers API`, the key version must be either version 2021-02-23 or 2021-03-23 for it it to function_
 
 <!-- DOCS-IGNORE:start -->

--- a/node/clients/digitalRiver.ts
+++ b/node/clients/digitalRiver.ts
@@ -58,6 +58,22 @@ export default class DigitalRiver extends ExternalClient {
     })
   }
 
+  // getTaxIds
+  public async createTaxId({
+    settings,
+    taxIdBody,
+  }: {
+    settings: AppSettings
+    taxIdBody: DRCreateTaxIdentifierRequest
+  }): Promise<DRTaxIdentifiersResponse> {
+    return this.http.post(`/tax-identifiers`, JSON.stringify(taxIdBody), {
+      headers: {
+        Authorization: `Bearer ${settings.digitalRiverToken}`,
+        'Content-Type': `application/json`,
+      },
+    })
+  }
+
   // createCustomer
   public async createCustomer({
     settings,

--- a/node/global.d.ts
+++ b/node/global.d.ts
@@ -506,3 +506,8 @@ interface DRTaxIdentifierResponse {
   updatedTime: string
   applicability: any[]
 }
+
+interface DRCreateTaxIdentifierRequest {
+  type: string
+  value: string
+}

--- a/node/index.ts
+++ b/node/index.ts
@@ -32,6 +32,7 @@ import {
   digitalRiverSkuSync,
   digitalRiverCustomers,
   digitalRiverTaxIds,
+  digitalRiverCreateTaxIds,
 } from './middlewares/digitalRiver'
 import { throttle } from './middlewares/throttle'
 
@@ -126,6 +127,9 @@ export default new Service<Clients, RecorderState, ParamsContext>({
     catalogSync: method({ POST: [digitalRiverCatalogSync] }),
     catalogLogs: method({ GET: [digitalRiverCatalogLogs] }),
     getAllCustomers: method({ GET: [digitalRiverCustomers] }),
-    getAllTaxIds: method({ GET: [digitalRiverTaxIds] }),
+    taxIds: method({
+      GET: [digitalRiverTaxIds],
+      POST: [digitalRiverCreateTaxIds],
+    }),
   },
 })

--- a/node/middlewares/checkout.ts
+++ b/node/middlewares/checkout.ts
@@ -313,6 +313,7 @@ export async function digitalRiverCreateCheckout(
     checkoutId: checkoutResponse.id,
     paymentSessionId:
       checkoutResponse.paymentSessionId || checkoutResponse.payment.session.id,
+    customerId: checkoutResponse.customerId,
   }
 
   await next()

--- a/node/middlewares/digitalRiver.ts
+++ b/node/middlewares/digitalRiver.ts
@@ -2,6 +2,7 @@
 import pThrottle from 'p-throttle'
 import type { EventContext } from '@vtex/api'
 import { ResolverError } from '@vtex/api'
+import { json } from 'co-body'
 
 import {
   countries,
@@ -296,6 +297,60 @@ export async function digitalRiverTaxIds(
     ctx.body = { message: 'Tax Ids can not be found' }
   }
 
+  ctx.status = 200
+  await next()
+}
+
+export async function digitalRiverCreateTaxIds(
+  ctx: Context,
+  next: () => Promise<unknown>
+) {
+  const {
+    clients: { apps, digitalRiver, orderForm },
+    vtex: { logger },
+    request: { headers },
+  } = ctx
+
+  const app: string = getAppId()
+  const settings = await apps.getAppSettings(app)
+
+  const taxIdBody = (await json(ctx.req)) as any
+
+  const { orderformid } = headers
+
+  const orderFormData = await orderForm.getOrderForm(
+    orderformid,
+    settings.vtexAppKey,
+    settings.vtexAppToken
+  )
+
+  const email = orderFormData.clientProfileData?.email
+
+  // If orderFormId doesn't have an email associated to it, it will not authorize
+  if (!email) {
+    throw new Error('Unauthorized application!')
+  }
+
+  let taxIdResult = null
+
+  try {
+    taxIdResult = await digitalRiver.createTaxId({
+      settings,
+      taxIdBody,
+    })
+  } catch (err) {
+    logger.error({
+      error: err,
+      message: 'DigitalRiverGetAllTaxIds-getTaxIds',
+    })
+
+    throw new ResolverError({
+      message: 'Get all tax ids failed',
+      error: err,
+    })
+  }
+
+  ctx.body = taxIdResult
   ctx.status = 200
   await next()
 }

--- a/node/service.json
+++ b/node/service.json
@@ -76,7 +76,7 @@
       "path": "/_v/api/digital-river/customers",
       "public": true
     },
-    "getAllTaxIds": {
+    "taxIds": {
       "path": "/_v/api/digital-river/tax-identifiers",
       "public": true
     }


### PR DESCRIPTION
Make a post request to `/_v/api/digital-river/tax-identifiers` to create a new `/tax-identifiers`
Sample request
```
{
    "type": "uk",
    "value": "GB123456789"
}
```