### PR TITLE
[DIGITALRIV-10] added taxIdPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Attached taxId to checkout whenever present
+
 ## [1.2.0] - 2021-11-01
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -225,7 +225,13 @@ async function initDigitalRiver(orderForm) {
 
   fetch(`${__RUNTIME__.rootPath || ``}/_v/api/digital-river/checkout/create`, {
     method: 'POST',
-    body: JSON.stringify({ orderFormId: orderForm.orderFormId }),
+    body: JSON.stringify({ orderFormId: orderForm.orderFormId, taxIdPayload: { // NOTE: The taxIdPayload field is optional
+      taxId: {
+        "type": "uk",
+        "value": "GB999999999"
+      },
+      customerType: "business"
+    }}),
   })
     .then((response) => {
       return response.json()

--- a/docs/README.md
+++ b/docs/README.md
@@ -472,7 +472,31 @@ _Example Response:_
 }
 ```
 
-> ⚠️ _For `/tax-identifiers API`, the key version must be either version 2021-02-23 or 2021-03-23 for it it to function_
+
+
+| Field            | Value                                                                                       |
+|------------------|---------------------------------------------------------------------------------------------|
+| **URI**          | /_v/api/digital-river/checkout/create                                                   |
+| **METHOD**       | POST                                                                                         |
+| **API Usage**    | Creates Checkout [Digital River API](https://www.digitalriver.com/docs/digital-river-api-reference/#operation/createCheckouts) |
+
+> ⚠️ _The taxId type must match the country where the product is shipped to. Moreover, the taxId value must be valid. The `customerType` field must be either business or individual. Please See the supported customerType with respect to the nation it is shipped to. [Supported TaxId Types](https://docs.digitalriver.com/digital-river-api/checkouts/creating-checkouts/tax-identifiers#supported-tax-identifiers)_
+
+_Example Request:_
+```json
+{
+  "orderFormId": "orderFormId",
+  "taxIdPayload": {
+    "taxId": {
+      "type": "uk",
+      "value": "GB999999999"
+    },
+    "customerType": "business" // Or "individual"
+  }
+}
+```
+
+> ⚠️ _For `/create API` to utilize the taxIdPayload, the key version must be either version 2021-02-23 or 2021-03-23 for it it to function._
 
 <!-- DOCS-IGNORE:start -->
 

--- a/node/clients/digitalRiver.ts
+++ b/node/clients/digitalRiver.ts
@@ -58,14 +58,14 @@ export default class DigitalRiver extends ExternalClient {
     })
   }
 
-  // getTaxIds
+  // createTaxId
   public async createTaxId({
     settings,
     taxIdBody,
   }: {
     settings: AppSettings
     taxIdBody: DRCreateTaxIdentifierRequest
-  }): Promise<DRTaxIdentifiersResponse> {
+  }): Promise<DRTaxIdentifierResponse> {
     return this.http.post(`/tax-identifiers`, JSON.stringify(taxIdBody), {
       headers: {
         Authorization: `Bearer ${settings.digitalRiverToken}`,

--- a/node/global.d.ts
+++ b/node/global.d.ts
@@ -82,6 +82,11 @@ interface DRCheckoutPayload {
   metadata?: CheckoutMetadata
   shippingChoice: CheckoutShippingChoice | null
   locale: string
+  customerType?: string
+  taxIdentifiers?: DRCheckoutTaxIdentifiers[]
+}
+interface DRCheckoutTaxIdentifiers {
+  id: string
 }
 interface DRCheckoutResponse {
   id: string

--- a/node/middlewares/checkout.ts
+++ b/node/middlewares/checkout.ts
@@ -9,6 +9,13 @@ import type { SessionFields } from '../resolvers/session/sessionResolver'
 
 interface CreateCheckoutRequest {
   orderFormId: string
+  taxIdPayload?: {
+    taxId: {
+      type: string
+      value: string
+    }
+    customerType: string
+  }
 }
 interface UpdateCheckoutRequest {
   checkoutId: string
@@ -237,6 +244,34 @@ export async function digitalRiverCreateCheckout(
     }
   }
 
+  const taxIdPayload = createCheckoutRequest?.taxIdPayload
+
+  let taxIdResult = null
+
+  if (taxIdPayload) {
+    try {
+      taxIdResult = await digitalRiver.createTaxId({
+        settings,
+        taxIdBody: taxIdPayload.taxId,
+      })
+    } catch (err) {
+      logger.error({
+        error: err,
+        message: 'DigitalRiverCreateCheckout-createTaxIdFailed',
+      })
+
+      throw new ResolverError({
+        message: 'Create Tax Id Failed',
+        error: err,
+      })
+    }
+  }
+
+  logger.info({
+    message: 'DigitalRiverCreateCheckout-createTaxId',
+    taxIdResult,
+  })
+
   const checkoutPayload: DRCheckoutPayload = {
     applicationId,
     currency: orderFormData?.storePreferencesData?.currencyCode ?? 'USD',
@@ -277,6 +312,11 @@ export async function digitalRiverCreateCheckout(
       description: '',
       serviceLevel: '',
     },
+  }
+
+  if (taxIdResult) {
+    checkoutPayload.customerType = taxIdPayload?.customerType
+    checkoutPayload.taxIdentifiers = [{ id: taxIdResult.id }]
   }
 
   logger.info({


### PR DESCRIPTION
Added the ability to add taxIdPayload to request and attach taxId to checkout/order
Currently being tested by motorola in case of regression (Keys must update to version 2021-02-23 or 2021-03-23 for this to function, though changes should support older keys)
```
{
  "orderFormId": "orderFormId",
  "taxIdPayload": {
    "taxId": {
      "type": "uk",
      "value": "GB999999999"
    },
    "customerType": "business" // Or "individual"
  }
}
```
