### PR TITLE
[DIGITALRIV-13] Disable auto retry of DR API requests, increase timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.0.0] - 2021-11-23
+### Fixed
 
+- Disable automatic retry of Digital River API requests and increase timeout
+
+## [2.0.0] - 2021-11-23
 
 ### Added
 

--- a/node/index.ts
+++ b/node/index.ts
@@ -41,13 +41,13 @@ import {
 } from './middlewares/digitalRiver'
 import { throttle } from './middlewares/throttle'
 
-const TIMEOUT_MS = 800
+const TIMEOUT_MS = 5000
 
 const clients: ClientsConfig<Clients> = {
   implementation: Clients,
   options: {
     default: {
-      retries: 2,
+      retries: 0,
       timeout: TIMEOUT_MS,
     },
   },


### PR DESCRIPTION
Recently we've noticed an issue where Digital River payments were failing to authorize because when the app goes to POST /orders to create the order in Digital River's system, it gets a 409 error response saying that the order "already exists". The theory is that this is occurring because the Digital River client in the app is set to perform 2 automatic retries. In other words, the app sends one request which times out (timeout was set to 800ms) and then sends a second request. By this point the first request has succeeded but the app missed its response, and only the second error response is recorded.

As a simple solution to this problem, this PR disables the automatic retry and increases the timeout. The idea here is that the app will only ever send one request to Digital River (per operation) and we will give them more time to respond.  I am also opening a matching PR for the 1.x version.

For testing, I've published this fix as 2.0.1-beta.0 which is currently installed at sandboxusdev.myvtex.com (master). Here's an order that was successfully placed and settled using this new version: https://sandboxusdev.myvtex.com/admin/checkout/#/orders/1179880364253-01