### PR TITLE
[DIGITALRIV-13] (1.x) Disable auto retry of DR API requests, increase timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Disabled automatic retry of Digital River API requests and increased timeout
+
 ## [1.3.0] - 2021-11-08
 
 ### Added

--- a/node/index.ts
+++ b/node/index.ts
@@ -36,13 +36,13 @@ import {
 } from './middlewares/digitalRiver'
 import { throttle } from './middlewares/throttle'
 
-const TIMEOUT_MS = 800
+const TIMEOUT_MS = 5000
 
 const clients: ClientsConfig<Clients> = {
   implementation: Clients,
   options: {
     default: {
-      retries: 2,
+      retries: 0,
       timeout: TIMEOUT_MS,
     },
   },


### PR DESCRIPTION
Same fix as https://github.com/vtex-apps/digital-river/pull/46 but for the 1.x major.